### PR TITLE
Changed code to use highest bitrate stream in case of same resolution

### DIFF
--- a/default.py
+++ b/default.py
@@ -165,10 +165,15 @@ def _getBestVideoUrl(json):
     url = None
     resolution = _getVideoResolution()
     last_resolution=0
+    last_encoding_rate=0
     for stream in json.get('renditions', []):
         test_resolution = stream.get('frameHeight', 0)
-        if test_resolution>=last_resolution and test_resolution<=resolution:
+        test_encoding_rate = stream.get('encodingRate', 0)
+        if test_resolution>last_resolution:
+            last_encoding_rate = 0
+        if test_resolution>=last_resolution and test_resolution<=resolution and test_encoding_rate>last_encoding_rate:
             last_resolution = test_resolution
+            last_encoding_rate = test_encoding_rate
             url = stream.get('url', None)
         pass
     


### PR DESCRIPTION
Hi Bromix,
when watching the "Goldrausch in Alaska" streams (e.g. "Die ganze Wahrheit") with kodi they seemed slightly blurry compared to website playback. When checking the plugin I saw that there are two 720p streams offered. Unfortunately in the mentioned case the low-quality stream is selected. This patch should fix the issue.
Best regards,
 Thimo